### PR TITLE
chore: refactor debug exception mode

### DIFF
--- a/src/leihs/inventory/server/swagger_api.clj
+++ b/src/leihs/inventory/server/swagger_api.clj
@@ -44,7 +44,7 @@
             [ring.util.response :as response]
             [taoensso.timbre :refer [debug error warn]]))
 
-(def ^:dynamic middlewares [wrap-handle-coercion-error
+(def middlewares [wrap-handle-coercion-error
                             db/wrap-tx
                             core-routing/wrap-canonicalize-params-maps
                             muuntaja/format-middleware
@@ -80,15 +80,11 @@
                             muuntaja/format-negotiate-middleware
                             muuntaja/format-response-middleware
                             exception/exception-middleware
+                            debug-mw/wrap-debug
                             muuntaja/format-request-middleware
                             coercion/coerce-response-middleware
                             coercion/coerce-request-middleware
                             multipart/multipart-middleware])
-
-(def ^:dynamic middlewares
-  (if (debug-mw/debug-mode?)
-    (into [] (interpose debug-mw/wrap-debug middlewares))
-    middlewares))
 
 (defn create-app [options]
   (let [router (ring/router

--- a/src/leihs/inventory/server/utils/debug_handler.clj
+++ b/src/leihs/inventory/server/utils/debug_handler.clj
@@ -1,25 +1,12 @@
 (ns leihs.inventory.server.utils.debug-handler
-  (:require [logbug.thrown :as thrown]
-            [taoensso.timbre :refer [debug error]]))
-
-(defonce ^:private DEBUG true)
-
-(defn debug-mode? [] DEBUG)
+  (:require
+   [taoensso.timbre :refer [debug error]]))
 
 (defn wrap-debug [handler]
   (fn [request]
-    (let [wrap-debug-level (or (:wrap-debug-level request) 0)]
-      (try
-        (debug "RING-LOGGING-WRAPPER"
-               {:wrap-debug-level wrap-debug-level
-                :request request})
-        (let [response (handler (assoc request :wrap-debug-level (inc wrap-debug-level)))]
-          (debug "RING-LOGGING-WRAPPER"
-                 {:wrap-debug-level wrap-debug-level
-                  :response response})
-          response)
-        (catch Exception ex
-          (error "RING-LOGGING-WRAPPER CAUGHT EXCEPTION "
-                 {:wrap-debug-level wrap-debug-level} (ex-message ex))
-          (error "RING-LOGGING-WRAPPER CAUGHT EXCEPTION " ex)
-          (throw ex))))))
+    (try
+     (handler request)
+     (catch Exception ex
+       (error (ex-message ex))
+       (debug ex)
+       (throw ex)))))


### PR DESCRIPTION
i have simplified and fixed the debug exception mode:
* no need for dynamic middleware chain and interposing the wrapper
* the wrapper is needed just once at the correct position in the middleware chain: before the reitit exception middleware swallows the exception cause and makes the response map
* i simplified the stacktrace output. it is well formatted and colored now.
* multiple debug outputs in the log are fixed too
* the activation of the debug output is configured via our standard logging setup. one needs to activate the respective namespace `leihs.inventory.server.utils.debug-handler` in `logging.cljc`
* exceptions raised before in the middleware chain are dealt with by web server itself. this needs to be fixed in future. 