### PR TITLE
Mk/refactor debug test

### DIFF
--- a/src/leihs/inventory/server/resources/models/routes.clj
+++ b/src/leihs/inventory/server/resources/models/routes.clj
@@ -103,13 +103,16 @@
            :coercion reitit.coercion.schema/coercion
            :middleware [accept-json-middleware]
            :swagger {:produces ["application/json"]}
+           :summary "TESTA"
 
            :parameters {:query {(s/optional-key :page) s/Int
                                 (s/optional-key :size) s/Int
                                 ;(s/optional-key :sort_by) (s/enum :manufacturer-asc :manufacturer-desc :product-asc :product-desc)
                                 ;(s/optional-key :filter_manufacturer) s/Str
                                 ;(s/optional-key :filter_product) s/Str
-                                }}
+                                }
+                        :path {:shit s/Str}
+                        }
            :handler get-models-compatible-handler
            :responses {200 {:description "OK"
                             :body s/Any}
@@ -121,12 +124,15 @@
            :accept "application/json"
            :coercion reitit.coercion.schema/coercion
            :middleware [accept-json-middleware]
+           :summary "TESTA"
            :swagger {:produces ["application/json"]}
            :parameters {:path {:model_id s/Uuid}}
            :handler get-models-compatible-handler
            :responses {200 {:description "OK"
-                            :body s/Any}
-                       404 {:description "Not Found"}
+                            ;:body s/Any}
+                       :body s/Int}
+
+           404 {:description "Not Found"}
                        500 {:description "Internal Server Error"}}}}]
 
    ;; /inventory/models/*
@@ -467,7 +473,8 @@
             :middleware [(permission-by-role-and-pool roles/min-role-lending-manager)]
             :responses {200 {:description "OK"
                              ;; TODO
-                             :body mc/item-response-get}
+                             ;:body mc/item-response-get}
+                             :body int?}
                         404 {:description "Not Found"}
                         500 {:description "Internal Server Error"}}}}]]
 
@@ -527,17 +534,18 @@
                          500 {:description "Internal Server Error"}}}
 
       :get {:accept "application/json"
-            :summary "(DEV) | Dynamic-Form-Handler: Fetch form data | Fetch fields by Role [v0]"
+            :summary "(DEV) | Dynamic-Form-Handler: Fetch form data | Fetch fields by Role [v0] TESTA"
             :description "Permitted access for:\n- lending_manager\n- inventory_manager"
             :coercion spec/coercion
             :parameters {:path {:pool_id uuid?}}
             :handler fetch-package-handler-by-pool-form
             :middleware [(permission-by-role-and-pool roles/min-role-lending-manager)]
-            :responses {200 {:body {:data {:inventory_code string?
-                                           :inventory_pool_id uuid?
-                                           :responsible_department any?}
-                                    :fields [any?]}
-                             :description "OK"}
+            ;:responses {200 {:body {:data {:inventory_code string?
+            :responses {200 {:body int?}
+                                           ;:inventory_pool_id uuid?
+                                           ;:responsible_department any?}
+                                    ;:fields [any?]}
+                             ;:description "OK"}
                         401 {:description "Unauthorized: invalid role for the requested pool or method"
                              :body {:error string?}}
                         404 {:description "Not Found"}

--- a/src/leihs/inventory/server/routes.clj
+++ b/src/leihs/inventory/server/routes.clj
@@ -75,6 +75,7 @@
    (token-routes)])
 
 (defn get-sign-in [request]
+  (+ 1 "a")
   (let [mtoken (anti-csrf-token request)
         query (convert-to-map (:query-params request))
         params (-> {:authFlow {:returnTo (or (:return-to query) "/inventory/models")}
@@ -105,6 +106,9 @@
         resp))))
 
 (defn get-sign-out [request]
+  ;(assert (< 200 100) "x must be less than 100") ;; no log-entry
+  (throw (Exception. "Something went wrong"))
+
   (let [uuid (get-in request [:cookies constants/ANTI_CSRF_TOKEN_COOKIE_NAME :value])
         params {:authFlow {:returnTo "/inventory/models"}
                 :csrfToken (when consts/ACTIVATE-SET-CSRF
@@ -142,7 +146,7 @@
              :coercion reitit.coercion.schema/coercion
              :handler post-sign-in}
 
-      :get {:summary "HTML | Get sign-in page"
+      :get {:summary "HTML | Get sign-in page TESTA"
             :accept "text/html"
             :swagger {:consumes ["text/html"]
                       :produces ["text/html" "application/json"]}
@@ -156,7 +160,7 @@
              :swagger {:produces ["text/html" "application/json"]}
              :handler post-sign-out}
       :get {:accept "text/html"
-            :summary "HTML | Get sign-out page"
+            :summary "HTML | Get sign-out page TESTA"
             :handler get-sign-out}}]]
 
    ["inventory"

--- a/src/leihs/inventory/server/swagger_api.clj
+++ b/src/leihs/inventory/server/swagger_api.clj
@@ -44,7 +44,7 @@
             [ring.util.response :as response]
             [taoensso.timbre :refer [debug error warn]]))
 
-(def ^:dynamic middlewares [wrap-handle-coercion-error
+(def middlewares [wrap-handle-coercion-error
                             db/wrap-tx
                             core-routing/wrap-canonicalize-params-maps
                             muuntaja/format-middleware
@@ -80,15 +80,11 @@
                             muuntaja/format-negotiate-middleware
                             muuntaja/format-response-middleware
                             exception/exception-middleware
+                            debug-mw/wrap-debug
                             muuntaja/format-request-middleware
                             coercion/coerce-response-middleware
                             coercion/coerce-request-middleware
                             multipart/multipart-middleware])
-
-(def ^:dynamic middlewares
-  (if (debug-mw/debug-mode?)
-    (into [] (interpose debug-mw/wrap-debug middlewares))
-    middlewares))
 
 (defn create-app [options]
   (let [router (ring/router

--- a/src/leihs/inventory/server/utils/debug_handler.clj
+++ b/src/leihs/inventory/server/utils/debug_handler.clj
@@ -1,25 +1,12 @@
 (ns leihs.inventory.server.utils.debug-handler
-  (:require [logbug.thrown :as thrown]
-            [taoensso.timbre :refer [debug error]]))
-
-(defonce ^:private DEBUG true)
-
-(defn debug-mode? [] DEBUG)
+  (:require
+   [taoensso.timbre :refer [debug error]]))
 
 (defn wrap-debug [handler]
   (fn [request]
-    (let [wrap-debug-level (or (:wrap-debug-level request) 0)]
-      (try
-        (debug "RING-LOGGING-WRAPPER"
-               {:wrap-debug-level wrap-debug-level
-                :request request})
-        (let [response (handler (assoc request :wrap-debug-level (inc wrap-debug-level)))]
-          (debug "RING-LOGGING-WRAPPER"
-                 {:wrap-debug-level wrap-debug-level
-                  :response response})
-          response)
-        (catch Exception ex
-          (error "RING-LOGGING-WRAPPER CAUGHT EXCEPTION "
-                 {:wrap-debug-level wrap-debug-level} (ex-message ex))
-          (error "RING-LOGGING-WRAPPER CAUGHT EXCEPTION " ex)
-          (throw ex))))))
+    (try
+     (handler request)
+     (catch Exception ex
+       (error (ex-message ex))
+       (debug ex)
+       (throw ex)))))


### PR DESCRIPTION
Contains test examples to verify:

1. Coercion logging is independent of log level:
   - Returns 422 if request coercion fails: a reduced error is returned, and the full coercion error is logged.
   - Returns 500 if response coercion fails: a reduced error is returned, and the full coercion error is logged.
2. Behavior based on log level:
   - At [debug], the stack trace is logged as expected.
   - At [info], only the error message is logged.