### PR TITLE
feat: show edit options based on permissions

### DIFF
--- a/cider-ci/generators/feature-tasks.yml
+++ b/cider-ci/generators/feature-tasks.yml
@@ -93,6 +93,21 @@
   environment_variables:
     FEATURE_NAME: "Language 03"
     FEATURE: './spec/features/i18n/language-switcher_spec.rb[1:3]'
+'./spec/features/inventory-list/access_rights_spec.rb[1:1]':
+  name: "Access rights on inventory list 01"
+  environment_variables:
+    FEATURE_NAME: "Access rights on inventory list 01"
+    FEATURE: './spec/features/inventory-list/access_rights_spec.rb[1:1]'
+'./spec/features/inventory-list/access_rights_spec.rb[1:2]':
+  name: "Access rights on inventory list 02"
+  environment_variables:
+    FEATURE_NAME: "Access rights on inventory list 02"
+    FEATURE: './spec/features/inventory-list/access_rights_spec.rb[1:2]'
+'./spec/features/inventory-list/access_rights_spec.rb[1:3]':
+  name: "Access rights on inventory list 03"
+  environment_variables:
+    FEATURE_NAME: "Access rights on inventory list 03"
+    FEATURE: './spec/features/inventory-list/access_rights_spec.rb[1:3]'
 './spec/features/inventory-list/availability_counts_variations_spec.rb[1:1]':
   name: "Inventory list availability counts (models, packages, options, software) 01"
   environment_variables:

--- a/resources/public/inventory/assets/locales/de/translation.json
+++ b/resources/public/inventory/assets/locales/de/translation.json
@@ -409,7 +409,8 @@
           "add_license": "Lizenz hinzufügen",
           "copy_license": "Lizenz duplizieren",
           "add_package": "Paket hinzufügen",
-          "copy_package": "Paket duplizieren"
+          "copy_package": "Paket duplizieren",
+          "timeline": "Zeitleiste"
         }
       }
     },

--- a/resources/public/inventory/assets/locales/en/translation.json
+++ b/resources/public/inventory/assets/locales/en/translation.json
@@ -408,7 +408,8 @@
           "add_license": "Add license",
           "copy_license": "Duplicate license",
           "add_package": "Add package",
-          "copy_package": "Duplicate package"
+          "copy_package": "Duplicate package",
+          "timeline": "Timeline"
         }
       }
     },

--- a/spec/features/inventory-list/access_rights_spec.rb
+++ b/spec/features/inventory-list/access_rights_spec.rb
@@ -1,0 +1,200 @@
+require "features_helper"
+require_relative "../shared/common"
+
+feature "Access rights on inventory list", type: :feature do
+  # Searches for a model row by product name and yields within it.
+  def within_model_row(product, &block)
+    find("input[name='search']").set(product)
+    await_debounce
+    within find('[data-row="model"]', text: product, wait: 10), &block
+  end
+
+  # Expands a model row and returns the first revealed item sub-row.
+  def expand_model_row(product, item)
+    find("input[name='search']").set(product)
+    await_debounce
+    within find('[data-row="model"]', text: product, wait: 10) do
+      click_on "expand-button"
+    end
+    find('[data-row="item"]', text: item.inventory_code, wait: 10)
+  end
+
+  def assert_all_tabs_visible
+    expect(page).to have_link("Inventory List")
+    expect(page).to have_link("Advanced Search")
+    expect(page).to have_link("Statistics")
+    expect(page).to have_link("Entitlement Groups")
+    expect(page).to have_link("Templates")
+  end
+
+  def assert_only_inventory_list_tab_visible
+    expect(page).to have_link("Inventory List")
+    expect(page).to have_no_link("Advanced Search")
+    expect(page).to have_no_link("Statistics")
+    expect(page).to have_no_link("Entitlement Groups")
+    expect(page).to have_no_link("Templates")
+  end
+
+  %i[lending_manager inventory_manager].each do |role|
+    scenario "#{role} sees all tabs, the Add Inventory button, and edit buttons on every row" do
+      user = FactoryBot.create(:user, language_locale: "en-GB")
+      pool = FactoryBot.create(:inventory_pool)
+      room = FactoryBot.create(:room)
+
+      FactoryBot.create(:access_right,
+        inventory_pool: pool,
+        user: user,
+        role: role)
+
+      model = FactoryBot.create(:leihs_model,
+        product: "AR#{role}Model",
+        version: "1.0")
+
+      item = FactoryBot.create(:item,
+        leihs_model: model,
+        inventory_pool: pool,
+        owner: pool,
+        room: room)
+
+      software_model = FactoryBot.create(:leihs_model,
+        product: "AR#{role}Software",
+        version: "1.0",
+        type: "Software")
+
+      license = FactoryBot.create(:item,
+        leihs_model: software_model,
+        inventory_pool: pool,
+        owner: pool,
+        room: room)
+
+      pkg_model = FactoryBot.create(:leihs_model,
+        product: "AR#{role}Package",
+        version: "1.0",
+        is_package: true)
+
+      FactoryBot.create(:item,
+        leihs_model: pkg_model,
+        inventory_pool: pool,
+        owner: pool,
+        room: room)
+
+      login(user)
+      visit "/inventory/#{pool.id}/list?with_items=true&page=1&size=50&retired=false"
+
+      # All tabs are visible
+      assert_all_tabs_visible
+
+      # Add Inventory button is present
+      expect(page).to have_content("Add inventory")
+
+      # Model row (type "Model") has an edit button
+      within_model_row(model.product) do
+        expect(page).to have_link("edit")
+      end
+
+      # Item sub-row has an edit button
+      item_row = expand_model_row(model.product, item)
+      within(item_row) do
+        expect(page).to have_link("edit")
+      end
+
+      # Package model row (type "Package") has an edit button
+      within_model_row(pkg_model.product) do
+        expect(page).to have_link("edit")
+      end
+
+      # Software model row (type "Software") has an edit button
+      within_model_row(software_model.product) do
+        expect(page).to have_link("edit")
+      end
+
+      # License sub-row has an edit button
+      license_row = expand_model_row(software_model.product, license)
+      within(license_row) do
+        expect(page).to have_link("edit")
+      end
+    end
+  end
+
+  scenario "group_manager sees only the Inventory List tab, no Add Inventory button, Timeline on model rows, and no edit buttons on item rows" do
+    user = FactoryBot.create(:user, language_locale: "en-GB")
+    pool = FactoryBot.create(:inventory_pool)
+    room = FactoryBot.create(:room)
+
+    FactoryBot.create(:access_right,
+      inventory_pool: pool,
+      user: user,
+      role: :group_manager)
+
+    model = FactoryBot.create(:leihs_model,
+      product: "ARGroupManagerModel",
+      version: "1.0")
+
+    item = FactoryBot.create(:item,
+      leihs_model: model,
+      inventory_pool: pool,
+      owner: pool,
+      room: room)
+
+    software_model = FactoryBot.create(:leihs_model,
+      product: "ARGroupManagerSoftware",
+      version: "1.0",
+      type: "Software")
+
+    license = FactoryBot.create(:item,
+      leihs_model: software_model,
+      inventory_pool: pool,
+      owner: pool,
+      room: room)
+
+    pkg_model = FactoryBot.create(:leihs_model,
+      product: "ARGroupManagerPackage",
+      version: "1.0",
+      is_package: true)
+
+    FactoryBot.create(:item,
+      leihs_model: pkg_model,
+      inventory_pool: pool,
+      owner: pool,
+      room: room)
+
+    login(user)
+    visit "/inventory/#{pool.id}/list?with_items=true&page=1&size=50&retired=false"
+
+    # Only the Inventory List tab is visible
+    assert_only_inventory_list_tab_visible
+
+    # Add Inventory button is not present
+    expect(page).to have_no_selector('[data-test-id="add-inventory-dropdown"]')
+
+    # Model row (type "Model") has a Timeline button, no edit button
+    within_model_row(model.product) do
+      expect(page).to have_link("Timeline")
+      expect(page).to have_no_link("edit")
+    end
+
+    # Item sub-row has no visible edit button
+    item_row = expand_model_row(model.product, item)
+    within(item_row) do
+      expect(page).to have_no_link("edit")
+    end
+
+    # Package model row (type "Package") has a Timeline button, no edit button
+    within_model_row(pkg_model.product) do
+      expect(page).to have_link("Timeline")
+      expect(page).to have_no_link("edit")
+    end
+
+    # Software model row (type "Software") has a Timeline button, no edit button
+    within_model_row(software_model.product) do
+      expect(page).to have_link("Timeline")
+      expect(page).to have_no_link("edit")
+    end
+
+    # License sub-row has no visible edit button
+    license_row = expand_model_row(software_model.product, license)
+    within(license_row) do
+      expect(page).to have_no_link("edit")
+    end
+  end
+end

--- a/src/leihs/inventory/client/lib/hooks.cljs
+++ b/src/leihs/inventory/client/lib/hooks.cljs
@@ -1,7 +1,27 @@
 (ns leihs.inventory.client.lib.hooks
-  (:require [uix.core :as uix :refer [defhook]]))
+  (:require ["react-router-dom" :as router]
+            [leihs.core.core :refer [detect]]
+            [leihs.inventory.client.lib.utils :refer [jc cj]]
+            [uix.core :as uix :refer [defhook]]))
 
 ;; NOTE: would be nicer to user defhook macro, but somehow the linting is broken ( maybe beacause of uix version? ) 
+
+(defn use-current-pool []
+  (let [[current-pool set-current-pool!] (uix/use-state nil)
+        {:keys [pool-id]} (jc (router/useParams))
+        profile (router/useRouteLoaderData "root")
+        available_inventory_pools (-> profile
+                                      :profile
+                                      :available_inventory_pools)]
+
+    (uix/use-effect
+     (fn []
+       (let [pool-id (->> available_inventory_pools (detect #(= pool-id (:id %))))]
+         (when pool-id
+           (set-current-pool! pool-id))))
+     [pool-id available_inventory_pools])
+
+    current-pool))
 
 ;; NOTE: docs https://usehooks.com/usedebounce
 (defn use-debounce [value delay]
@@ -115,7 +135,6 @@
 
 (defn use-network-state []
   (let [cache (uix/use-ref {})
-
         get-snapshot (uix/use-callback
                       (fn []
                         (let [online (.-onLine js/navigator)

--- a/src/leihs/inventory/client/routes/components/header.cljs
+++ b/src/leihs/inventory/client/routes/components/header.cljs
@@ -15,6 +15,7 @@
    [clojure.string :as str]
    [leihs.core.core :refer [detect]]
    [leihs.inventory.client.lib.csrf :as csrf]
+   [leihs.inventory.client.lib.hooks :as hooks]
    [leihs.inventory.client.lib.utils :refer [jc cj]]
    [leihs.inventory.client.routes.components.theme-provider :refer [use-theme]]
    [uix.core :as uix :refer [$ defui]]
@@ -24,9 +25,9 @@
   (let [[t] (useTranslation)
         {:keys [pool-id]} (jc (router/useParams))
         {:keys [theme set-theme]} (use-theme)
+        current-pool (hooks/use-current-pool)
         fetcher (router/useFetcher)
         last-fetcher-data (uix/use-ref nil)
-        current-pool (->> available_inventory_pools (detect #(= pool-id (:id %))))
         current-lending-url (->> navigation :manage_nav_items (detect #(= (:name current-pool) (:name %))) :href)
         current-search-url (str/replace (or current-lending-url "") "/daily" "/search")
         current-lang (.. i18n -language)]

--- a/src/leihs/inventory/client/routes/pools/inventory/layout.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/layout.cljs
@@ -13,6 +13,7 @@
    ["react-router-dom" :as router :refer [generatePath Link Outlet]]
    [clojure.string :as str]
    [leihs.core.core :refer [detect]]
+   [leihs.inventory.client.lib.hooks :as hooks]
    [leihs.inventory.client.lib.utils :refer [cj jc]]
    [uix.core :as uix :refer [$ defui]]
    [uix.dom]))
@@ -22,29 +23,36 @@
         [open? set-open!] (uix/use-state false)
         pool-id (:pool-id (jc (router/useParams)))
         location (router/useLocation)
+        current-pool (hooks/use-current-pool)
+        permission (:permission current-pool)
         last-segment (-> (.-pathname location)
                          (str/split #"/")
                          last)
         [t] (useTranslation)
         tabs [{:segment "list"
                :search "?with_items=true&page=1&size=50"
-               :label (t "pool.models.tabs.inventory_list")}
+               :label (t "pool.models.tabs.inventory_list")
+               :show true}
 
               {:segment "advanced-search"
                :search ""
-               :label (t "pool.models.tabs.advanced_search")}
+               :label (t "pool.models.tabs.advanced_search")
+               :show (= permission "edit")}
 
               {:segment "statistics"
                :search ""
-               :label (t "pool.models.tabs.statistics")}
+               :label (t "pool.models.tabs.statistics")
+               :show (= permission "edit")}
 
               {:segment "entitlement-groups"
                :search ""
-               :label (t "pool.models.tabs.entitlement_groups")}
+               :label (t "pool.models.tabs.entitlement_groups")
+               :show (= permission "edit")}
 
               {:segment "templates"
                :search ""
-               :label (t "pool.models.tabs.templates")}]
+               :label (t "pool.models.tabs.templates")
+               :show (= permission "edit")}]
 
         {:keys [profile]} (router/useRouteLoaderData "root")
         pool (->> profile :available_inventory_pools (detect #(= (:id %) pool-id)))]
@@ -105,114 +113,116 @@
              ($ TabsList
                 (for [tab tabs]
                   (let [_ (str "/inventory/:pool-id/" (:segment tab) (:search tab))]
-                    ($ TabsTrigger
-                       {:key (:segment tab)
-                        :asChild true
-                        :value (:segment tab)}
-                       ($ Link
-                          {:to (str (:segment tab) "/" (:search tab))
-                           :state #js {:searchParams (.. location -search)}
-                           :viewTransition true}
-                          ($ :span {:class-name "inline md:hidden"}
-                             (case (:segment tab)
-                               "list" ($ List {:className "h-4 w-4"})
-                               "advanced-search" ($ Search {:className "h-4 w-4"})
-                               "statistics" ($ ChartArea {:className "h-4 w-4"})
-                               "entitlement-groups" ($ Users {:className "h-4 w-4"})
-                               "templates" ($ LayoutTemplate {:className "h-4 w-4"})))
-                          ($ :span {:class-name "hidden md:inline"}
-                             (:label tab)))))))
+                    (when (:show tab)
+                      ($ TabsTrigger
+                         {:key (:segment tab)
+                          :asChild true
+                          :value (:segment tab)}
+                         ($ Link
+                            {:to (str (:segment tab) "/" (:search tab))
+                             :state #js {:searchParams (.. location -search)}
+                             :viewTransition true}
+                            ($ :span {:class-name "inline md:hidden"}
+                               (case (:segment tab)
+                                 "list" ($ List {:className "h-4 w-4"})
+                                 "advanced-search" ($ Search {:className "h-4 w-4"})
+                                 "statistics" ($ ChartArea {:className "h-4 w-4"})
+                                 "entitlement-groups" ($ Users {:className "h-4 w-4"})
+                                 "templates" ($ LayoutTemplate {:className "h-4 w-4"})))
+                            ($ :span {:class-name "hidden md:inline"}
+                               (:label tab))))))))
 
-             ($ :div {:className "ml-auto"}
-                (case last-segment
-                  "list"
-                  ($ DropdownMenu {:open open?
-                                   :on-open-change set-open!}
-                     ($ DropdownMenuTrigger {:asChild "true"}
-                        ($ Button {:ref ref
-                                   :on-click #(set-open! (not open?))}
-                           ($ CirclePlus {:className "h-4 w-4"})
-                           ($ :span {:class-name "hidden md:inline"}
-                              (t "pool.models.dropdown.title"))))
+             (when (= permission "edit")
+               ($ :div {:className "ml-auto"}
+                  (case last-segment
+                    "list"
+                    ($ DropdownMenu {:open open?
+                                     :on-open-change set-open!}
+                       ($ DropdownMenuTrigger {:asChild "true"}
+                          ($ Button {:ref ref
+                                     :on-click #(set-open! (not open?))}
+                             ($ CirclePlus {:className "h-4 w-4"})
+                             ($ :span {:class-name "hidden md:inline"}
+                                (t "pool.models.dropdown.title"))))
 
-                     ($ DropdownMenuContent {:data-test-id "add-inventory-dropdown"
-                                             :align "start"}
+                       ($ DropdownMenuContent {:data-test-id "add-inventory-dropdown"
+                                               :align "start"}
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/models/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-slate-500"}
-                                 "M")
-                              (t "pool.models.dropdown.add_model")))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/models/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-slate-500"}
+                                   "M")
+                                (t "pool.models.dropdown.add_model")))
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/software/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-orange-500"}
-                                 "S")
-                              (t "pool.models.dropdown.add_software")))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/software/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-orange-500"}
+                                   "S")
+                                (t "pool.models.dropdown.add_software")))
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/options/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-emerald-500"}
-                                 "O")
-                              (t "pool.models.dropdown.add_option")))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/options/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-emerald-500"}
+                                   "O")
+                                (t "pool.models.dropdown.add_option")))
 
-                        ($ DropdownMenuSeparator)
+                          ($ DropdownMenuSeparator)
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/packages/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-lime-500"}
-                                 "P")
-                              (t "pool.models.dropdown.add_package")))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/packages/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center shadow-none bg-lime-500"}
+                                   "P")
+                                (t "pool.models.dropdown.add_package")))
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/items/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center bg-blue-500"}
-                                 (t "pool.models.list.item.badge"))
-                              (t "pool.models.dropdown.add_item")))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/items/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center bg-blue-500"}
+                                   (t "pool.models.list.item.badge"))
+                                (t "pool.models.dropdown.add_item")))
 
-                        ($ DropdownMenuItem {:asChild true}
-                           ($ Link {:state #js {:searchParams (.. location -search)}
-                                    :to (generatePath "/inventory/:pool-id/licenses/create"
-                                                      (cj {:pool-id pool-id}))
-                                    :viewTransition true}
-                              ($ Badge {:className "w-6 h-5 justify-center bg-yellow-500"}
-                                 "L")
-                              (t "pool.models.dropdown.add_license")))))
+                          ($ DropdownMenuItem {:asChild true}
+                             ($ Link {:state #js {:searchParams (.. location -search)}
+                                      :to (generatePath "/inventory/:pool-id/licenses/create"
+                                                        (cj {:pool-id pool-id}))
+                                      :viewTransition true}
+                                ($ Badge {:className "w-6 h-5 justify-center bg-yellow-500"}
+                                   "L")
+                                (t "pool.models.dropdown.add_license")))))
 
-                  "entitlement-groups"
-                  ($ Button {:asChild true}
-                     ($ Link {:state #js {:searchParams (.. location -search)}
-                              :to (generatePath "/inventory/:pool-id/entitlement-groups/create"
-                                                (cj {:pool-id pool-id}))
-                              :viewTransition true}
-                        ($ CirclePlus {:className "h-4 w-4"})
-                        (t "pool.models.add_entitlement_group")))
+                    "entitlement-groups"
+                    ($ Button {:asChild true}
+                       ($ Link {:state #js {:searchParams (.. location -search)}
+                                :to (generatePath "/inventory/:pool-id/entitlement-groups/create"
+                                                  (cj {:pool-id pool-id}))
+                                :viewTransition true}
+                          ($ CirclePlus {:className "h-4 w-4"})
+                          (t "pool.models.add_entitlement_group")))
 
-                  "templates"
-                  ($ Button {:asChild true}
-                     ($ Link {:state #js {:searchParams (.. location -search)}
-                              :to (generatePath "/inventory/:pool-id/templates/create"
-                                                (cj {:pool-id pool-id}))
-                              :viewTransition true}
-                        ($ CirclePlus {:className "h-4 w-4"})
-                        (t "pool.models.add_template")))
+                    "templates"
+                    ($ Button {:asChild true}
+                       ($ Link {:state #js {:searchParams (.. location -search)}
+                                :to (generatePath "/inventory/:pool-id/templates/create"
+                                                  (cj {:pool-id pool-id}))
+                                :viewTransition true}
+                          ($ CirclePlus {:className "h-4 w-4"})
+                          (t "pool.models.add_template")))
 
-                  ($ :<>))))
+                    ($ :<>)))))
 
           ($ TabsContent {:forceMount true
                           :tab-index -1}

--- a/src/leihs/inventory/client/routes/pools/inventory/list/components/table/item_row.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/list/components/table/item_row.cljs
@@ -9,13 +9,12 @@
    ["lucide-react" :refer [Image ChevronDown]]
    ["react-i18next" :refer [useTranslation]]
    ["react-router-dom" :as router :refer [Link]]
-
    [leihs.inventory.client.components.image-modal :refer [ImageModal]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.item-info :refer [ItemInfo]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.item-status :refer [ItemStatus]]
    [uix.core :as uix :refer [$ defui]]))
 
-(defui main [{:keys [item type isPackageItem]
+(defui main [{:keys [item type isPackageItem permission]
               :or {isPackageItem false}}]
 
   (let [location (router/useLocation)
@@ -59,49 +58,56 @@
           ($ ItemStatus {:item item}))
 
        ($ TableCell {:className "fit-content"}
-          ($ ButtonGroup
-             ($ Button {:variant "outline"
-                        :asChild true}
-                ($ Link {:state #js {:searchParams (.. location -search)}
-                         :to (case type
-                               "Software"
-                               (str "../licenses/" (:id item))
+          (if (= permission "read")
 
-                               "Package"
-                               (if isPackageItem
-                                 (str "../items/" (:id item))
-                                 (str "../packages/" (:id item)))
+            ($ Button {:variant "outline"
+                       :class-name "invisible"}
+               (t "pool.models.list.actions.timeline"))
 
-                               (str "../items/" (:id item)))
-                         :viewTransition true}
+            ($ ButtonGroup {:class-name (when (= permission "read")
+                                          "invisible")}
+               ($ Button {:variant "outline"
+                          :asChild true}
+                  ($ Link {:state #js {:searchParams (.. location -search)}
+                           :to (case type
+                                 "Software"
+                                 (str "../licenses/" (:id item))
 
-                   (t "pool.models.list.actions.edit")))
+                                 "Package"
+                                 (if isPackageItem
+                                   (str "../items/" (:id item))
+                                   (str "../packages/" (:id item)))
 
-             ($ DropdownMenu
-                ($ DropdownMenuTrigger {:asChild true}
-                   ($ Button {:data-test-id "edit-dropdown"
-                              :class-name ""
-                              :variant "outline"
-                              :size "icon"}
-                      ($ ChevronDown {:className "w-4 h-4"})))
-                ($ DropdownMenuContent {:align "start"}
-                   ($ DropdownMenuItem
-                      (case type
-                        "Software"
-                        ($ Link {:to (str "../licenses/create?fromItem=" (:id item))
-                                 :state #js {:searchParams (.. location -search)}
-                                 :viewTransition true}
-                           (t "pool.models.list.actions.copy_license"))
+                                 (str "../items/" (:id item)))
+                           :viewTransition true}
 
-                        ($ Link {:to (str "../items/create?fromItem=" (:id item))
-                                 :state #js {:searchParams (.. location -search)}
-                                 :viewTransition true}
-                           (t "pool.models.list.actions.copy_item")))
+                     (t "pool.models.list.actions.edit")))
 
-                      #_($ Link {:to (str "../items/create?fromItem=" (:id item))
-                                 :state #js {:searchParams (.. location -search)}
-                                 :viewTransition true}
-                           (t "pool.models.list.actions.copy_item"))))))))))
+               ($ DropdownMenu
+                  ($ DropdownMenuTrigger {:asChild true}
+                     ($ Button {:data-test-id "edit-dropdown"
+                                :class-name ""
+                                :variant "outline"
+                                :size "icon"}
+                        ($ ChevronDown {:className "w-4 h-4"})))
+                  ($ DropdownMenuContent {:align "start"}
+                     ($ DropdownMenuItem
+                        (case type
+                          "Software"
+                          ($ Link {:to (str "../licenses/create?fromItem=" (:id item))
+                                   :state #js {:searchParams (.. location -search)}
+                                   :viewTransition true}
+                             (t "pool.models.list.actions.copy_license"))
+
+                          ($ Link {:to (str "../items/create?fromItem=" (:id item))
+                                   :state #js {:searchParams (.. location -search)}
+                                   :viewTransition true}
+                             (t "pool.models.list.actions.copy_item")))
+
+                        #_($ Link {:to (str "../items/create?fromItem=" (:id item))
+                                   :state #js {:searchParams (.. location -search)}
+                                   :viewTransition true}
+                             (t "pool.models.list.actions.copy_item")))))))))))
 
 (def ItemRow
   (uix/as-react

--- a/src/leihs/inventory/client/routes/pools/inventory/list/components/table/model_row.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/list/components/table/model_row.cljs
@@ -14,6 +14,7 @@
    [clojure.string :as str]
    [leihs.inventory.client.components.image-modal :refer [ImageModal]]
    [leihs.inventory.client.lib.client :refer [http-client]]
+   [leihs.inventory.client.lib.hooks :as hooks]
    [leihs.inventory.client.lib.utils :refer [cj jc]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.expandable-row :refer [ExpandableRow]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.item-row :refer [ItemRow]]
@@ -25,7 +26,7 @@
                  :fields :in_stock_quantity
                  :model_id :parent_id :inventory_pool_id :search])
 
-(defui main [{:keys [model className]}]
+(defui main [{:keys [model className permission]}]
   (let [location (router/useLocation)
         {:keys [settings]} (router/useRouteLoaderData "root")
         [t] (useTranslation)
@@ -78,10 +79,12 @@
                                         ($ ItemRow {:key (:id element)
                                                     :type (:type model)
                                                     :is-package-item (:parent_id element)
-                                                    :item element})
+                                                    :item element
+                                                    :permission permission})
                                         ($ PackageRow {:key (:id element)
                                                        :type (:type model)
-                                                       :package element})))
+                                                       :package element
+                                                       :permission permission})))
                                     (:data result))))}
 
        ($ TableCell
@@ -132,42 +135,56 @@
                                   ": " (-> model :borrowable_quantity str))))))))
 
        ($ TableCell {:className "fit-content"}
-          ($ ButtonGroup
-             ($ Button {:variant "outline"
-                        :class-name ""
-                        :asChild true}
-                ($ Link {:state #js {:searchParams (.. location -search)}
-                         :to (case (-> model :type)
-                               "Model" (str "../models/" (:id model))
-                               "Package" (str "../models/" (:id model))
-                               "Option" (str "../options/" (:id model))
-                               "Software" (str "../software/" (:id model)))
-                         :viewTransition true}
-                   (t "pool.models.list.actions.edit")))
+          (if (= permission "read")
 
-             ($ DropdownMenu
-                ($ DropdownMenuTrigger {:asChild true}
-                   ($ Button {:data-test-id "edit-dropdown"
-                              :class-name ""
-                              :variant "outline"
-                              :size "icon"}
-                      ($ ChevronDown {:className "w-4 h-4"})))
-                ($ DropdownMenuContent {:align "start"}
-                   ($ DropdownMenuItem
-                      (case (-> model :type)
-                        "Package" ($ Link {:to (str "../models/" (:id model) "/packages/create")
+            ($ Button {:variant "outline"
+                       :asChild true}
+               ($ :a {:href (str "/manage/" pool-id "/models/" (:id model) "/timeline")
+                      :target "_blank"
+                      :rel "noreferrer"}
+                  (t "pool.models.list.actions.timeline")))
+
+            ($ ButtonGroup
+               ($ Button {:variant "outline"
+                          :asChild true}
+                  ($ Link {:state #js {:searchParams (.. location -search)}
+                           :to (case (-> model :type)
+                                 "Model" (str "../models/" (:id model))
+                                 "Package" (str "../models/" (:id model))
+                                 "Option" (str "../options/" (:id model))
+                                 "Software" (str "../software/" (:id model)))
+                           :viewTransition true}
+                     (t "pool.models.list.actions.edit")))
+
+               ($ DropdownMenu
+                  ($ DropdownMenuTrigger {:asChild true}
+                     ($ Button {:data-test-id "edit-dropdown"
+                                :class-name ""
+                                :variant "outline"
+                                :size "icon"}
+                        ($ ChevronDown {:className "w-4 h-4"})))
+                  ($ DropdownMenuContent {:align "start"}
+                     ($ DropdownMenuItem
+                        (case (-> model :type)
+                          "Package" ($ Link {:to (str "../models/" (:id model) "/packages/create")
+                                             :state #js {:searchParams (.. location -search)}
+                                             :viewTransition true}
+                                       (t "pool.models.list.actions.add_package"))
+                          "Model" ($ Link {:to (str "../models/" (:id model) "/items/create")
                                            :state #js {:searchParams (.. location -search)}
                                            :viewTransition true}
-                                     (t "pool.models.list.actions.add_package"))
-                        "Model" ($ Link {:to (str "../models/" (:id model) "/items/create")
-                                         :state #js {:searchParams (.. location -search)}
-                                         :viewTransition true}
-                                   (t "pool.models.list.actions.add_item"))
-                        "Software" ($ Link {:to (str "../software/" (:id model) "/licenses/create")
-                                            :state #js {:searchParams (.. location -search)}
-                                            :viewTransition true}
-                                      (t "pool.models.list.actions.add_license"))
-                        nil)))))))))
+                                     (t "pool.models.list.actions.add_item"))
+                          "Software" ($ Link {:to (str "../software/" (:id model) "/licenses/create")
+                                              :state #js {:searchParams (.. location -search)}
+                                              :viewTransition true}
+                                        (t "pool.models.list.actions.add_license"))
+                          nil))
+
+                     ($ DropdownMenuItem
+                        ($ :a {:href (str "/manage/" pool-id "/models/" (:id model) "/timeline")
+                               :target "_blank"
+                               :rel "noreferrer"}
+                           (t "pool.models.list.actions.timeline")))))))))))
 
 (def ModelRow
   (uix/as-react

--- a/src/leihs/inventory/client/routes/pools/inventory/list/components/table/package_row.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/list/components/table/package_row.cljs
@@ -13,6 +13,7 @@
    [clojure.string :as str]
    [leihs.inventory.client.components.image-modal :refer [ImageModal]]
    [leihs.inventory.client.lib.client :refer [http-client]]
+   [leihs.inventory.client.lib.hooks :as hooks]
    [leihs.inventory.client.lib.utils :refer [cj jc]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.expandable-row :refer [ExpandableRow]]
    [leihs.inventory.client.routes.pools.inventory.list.components.table.item-info :refer [ItemInfo]]
@@ -25,7 +26,7 @@
              "user_name" "model_name" "reservation_user_name" "url"
              "reservation_contract_id"])
 
-(defui main [{:keys [package type]}]
+(defui main [{:keys [package type permission]}]
   (let [location (router/useLocation)
         [t] (useTranslation)
         params (router/useParams)
@@ -74,7 +75,8 @@
                                         ($ ItemRow {:key (:id item)
                                                     :type type
                                                     :is-package-item true
-                                                    :item item})))
+                                                    :item item
+                                                    :permission permission})))
                                     (:data result))))}
 
        ($ TableCell
@@ -94,27 +96,32 @@
           ($ ItemStatus {:item package}))
 
        ($ TableCell {:className "fit-content"}
-          ($ ButtonGroup
-             ($ Button {:variant "outline"
-                        :asChild true}
-                ($ Link {:state #js {:searchParams (.. location -search)}
-                         :to (str "../packages/" (:id package))
-                         :viewTransition true}
-                   (t "pool.models.list.actions.edit")))
+          (if (= permission "read")
+            ($ Button {:variant "outline"
+                       :class-name "invisible"}
+               (t "pool.models.list.actions.timeline"))
 
-             ($ DropdownMenu
-                ($ DropdownMenuTrigger {:asChild true}
-                   ($ Button {:data-test-id "edit-dropdown"
-                              :class-name ""
-                              :variant "outline"
-                              :size "icon"}
-                      ($ ChevronDown {:className "w-4 h-4"})))
-                ($ DropdownMenuContent {:align "start"}
-                   ($ DropdownMenuItem
-                      ($ Link {:to (str (:id package) "/items/create")
-                               :state #js {:searchParams (.. location -search)}
-                               :viewTransition true}
-                         (t "pool.models.list.actions.add_item"))))))))))
+            ($ ButtonGroup
+               ($ Button {:variant "outline"
+                          :asChild true}
+                  ($ Link {:state #js {:searchParams (.. location -search)}
+                           :to (str "../packages/" (:id package))
+                           :viewTransition true}
+                     (t "pool.models.list.actions.edit")))
+
+               ($ DropdownMenu
+                  ($ DropdownMenuTrigger {:asChild true}
+                     ($ Button {:data-test-id "edit-dropdown"
+                                :class-name ""
+                                :variant "outline"
+                                :size "icon"}
+                        ($ ChevronDown {:className "w-4 h-4"})))
+                  ($ DropdownMenuContent {:align "start"}
+                     ($ DropdownMenuItem
+                        ($ Link {:to (str (:id package) "/items/create")
+                                 :state #js {:searchParams (.. location -search)}
+                                 :viewTransition true}
+                           (t "pool.models.list.actions.add_item")))))))))))
 
 (def PackageRow
   (uix/as-react

--- a/src/leihs/inventory/client/routes/pools/inventory/list/components/table/skeleton_row.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/list/components/table/skeleton_row.cljs
@@ -6,13 +6,13 @@
    ["@@/table" :refer [TableCell TableRow]]
    ["lucide-react" :refer [Ellipsis Image ChevronDown]]
    ["react-i18next" :refer [useTranslation]]
+
    [uix.core :as uix :refer [$ defui]]))
 
-(defui main [{:keys [col-span]}]
+(defui main [{:keys [permission]}]
   (let [[t] (useTranslation)]
 
     ($ TableRow {:class-name "shadow-[0_-0.5px_0_hsl(var(--border))] "}
-
        ($ TableCell
           ($ Skeleton {:className "w-[76px] h-9 ml-2"}))
 
@@ -30,17 +30,22 @@
           ($ Skeleton {:className "w-auto h-6"}))
 
        ($ TableCell
-          ($ Skeleton {:className ""}
-             ($ ButtonGroup {:class-name "invisible"}
-                ($ Button {:variant "outline"
-                           :class-name ""}
-                   (t "pool.models.list.actions.edit"))
+          ($ Skeleton
+             (if (= permission "read")
+               ($ Button {:variant "outline"
+                          :class-name "invisible"}
+                  (t "pool.models.list.actions.timeline"))
 
-                ($ Button {:data-test-id "edit-dropdown"
-                           :class-name ""
-                           :variant "outline"
-                           :size "icon"}
-                   ($ ChevronDown {:className "w-4 h-4"}))))))))
+               ($ ButtonGroup {:class-name "invisible"}
+                  ($ Button {:variant "outline"
+                             :class-name ""}
+                     (t "pool.models.list.actions.edit"))
+
+                  ($ Button {:data-test-id "edit-dropdown"
+                             :class-name ""
+                             :variant "outline"
+                             :size "icon"}
+                     ($ ChevronDown {:className "w-4 h-4"})))))))))
 
 (def SkeletonRow
   (uix/as-react

--- a/src/leihs/inventory/client/routes/pools/inventory/list/page.cljs
+++ b/src/leihs/inventory/client/routes/pools/inventory/list/page.cljs
@@ -36,6 +36,7 @@
                            mod-result))
         params (router/useParams)
         pool-id (aget params "pool-id")
+        {:keys [permission]} (hooks/use-current-pool)
 
         [to-last-page? set-to-last-page!] (uix/use-state false)
         [t] (useTranslation)
@@ -48,6 +49,7 @@
                               "50"))
         handle-reset (fn []
                        (navigate (str "?page=1&size=" size "&with_items=true")))
+
         is-desktop? (hooks/use-media-query "(min-width: 1280px)")]
 
     (uix/use-effect
@@ -134,9 +136,11 @@
                           (doall (for [i (range (if to-last-page?
                                                   last-page-rows
                                                   (:size pagination)))]
-                                   ($ SkeletonRow {:key i})))
+                                   ($ SkeletonRow {:key i
+                                                   :permission permission})))
                           (for [model models]
                             ($ ModelRow {:key (:id model)
+                                         :permission permission
                                          :model model})))))))))
 
        ($ CardFooter {:class-name "sticky bottom-0 bg-background z-10 rounded-b-xl  pt-6"


### PR DESCRIPTION
FE currently expects to have ```permission: ["edit"|"read"] property``` in ```available_inventory_pools``` in profile

```
"available_inventory_pools": [
        {
            "id": "8bd16d45-056d-5590-bc7f-12849f034351",
            "name": "Ausleihe Toni-Areal",
            "permission": "read"
        },
        {
            "id": "82a48074-8a4d-5d3b-b1dd-8e35954137e8",
            "name": "AVS-Ausstattung",
            "permission": "edit"
        },
        {
            "id": "8a4fa6e3-2b36-46b9-9508-212d4f5125c6",
            "name": "AV-Services",
            "permission": "read"
        },
        {
            "id": "5dd25b58-fa56-5095-bd97-2696d92c2fb1",
            "name": "IT-Zentrum",
            "permission": "edit"
        }
    ],
```

property ```permission``` is just a possibility and can be seen as draft

Further notice:
returned inventory pools in profile and navigation currenlty do not check if a inventory pool is ```active```
